### PR TITLE
add tekton and info about kustomize in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,39 @@ Three ways to manually deploy an application on Kubernetes:
 3. 
 
 ## Skaffold 
+
 ## Kustomize 
-..... 
+Checkout the `kustomize.yaml` mentioned in the README!
+
+The k8s deployment repo uses Kustomize to organize its deployment files. The following command will deploy the all of the required resources for the full `whereami` deployment.
+
+```bash
+$ cat k8s/kustomization.yaml
+resources:
+- ksa.yaml
+- deployment.yaml
+- service.yaml
+- configmap.yaml
+
+$ kubectl apply -k k8s
+serviceaccount/whereami created
+configmap/whereami created
+service/whereami created
+deployment.apps/whereami created
+```
+
+....
 
 ## Helm
 see whereami/helm-chart  
+
+## Tekton
+
+
+## Argo
+
+
+## Jenkins
+
+
+## Jenkins X

--- a/whereami/tekton/build-pipeline.yaml
+++ b/whereami/tekton/build-pipeline.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deploy-pipeline
+spec:
+  params:
+    - name: IMAGE
+      description: The name of the image to build and deploy.
+      type: string
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: build-image
+      taskRef:
+        name: build-docker-image
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE)
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: deploy
+      taskRef:
+        name: deploy-to-kubernetes
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE)
+      runAfter:
+        - build-image
+      workspaces:
+        - name: source
+          workspace: shared-workspace

--- a/whereami/tekton/run-pipeline.yaml
+++ b/whereami/tekton/run-pipeline.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: deploy-pipeline-run
+spec:
+  pipelineRef:
+    name: deploy-pipeline
+  params:
+    - name: IMAGE
+      value: gcr.io/your-project/whereami:latest
+  workspaces:
+    - name: shared-workspace
+      persistentVolumeClaim:
+        claimName: your-pvc

--- a/whereami/tekton/task-build-docker-image.yaml
+++ b/whereami/tekton/task-build-docker-image.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-docker-image
+spec:
+  params:
+    - name: IMAGE
+      description: The name of the image to build.
+      type: string
+  steps:
+    - name: build
+      image: gcr.io/kaniko-project/executor:latest
+      args:
+        - --dockerfile=/workspace/source/Dockerfile
+        - --context=/workspace/source
+        - --destination=$(params.IMAGE)
+  workspaces:
+    - name: source

--- a/whereami/tekton/task-deploy.yaml
+++ b/whereami/tekton/task-deploy.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-to-kubernetes
+spec:
+  params:
+    - name: IMAGE
+      description: The name of the image to deploy.
+      type: string
+  steps:
+    - name: deploy
+      image: bitnami/kubectl:latest
+      script: |
+        kubectl apply -f /workspace/source/k8s/deployment.yaml
+  workspaces:
+    - name: source


### PR DESCRIPTION
Summary:

Add basic `tekton` tasks, deploy, pipeline, and pipeline run yaml files!
Add in pointers to the README with regard to Kustomize documentation that exists in the base repo README. 