### PR TITLE
add in example argo yaml

### DIFF
--- a/whereami/argo/deploy.yaml
+++ b/whereami/argo/deploy.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: whereami
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/your-repo/whereami.git' # Change this to your repo
+    targetRevision: HEAD
+    path: k8s
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Summary:

- Add in example Argo yaml file to deploy `wheremi` application
- Add in a line in the README pointing to the folder